### PR TITLE
Fix/save pickle and requirements update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM nvidia/cuda:11.1.1-cudnn8-runtime-ubuntu20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    software-properties-common \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y \
+    python3.10 \
+    python3.10-dev \
+    wget \
+    curl \
+    git \
+    build-essential \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/python3.10 /usr/bin/python && \
+    curl -sS https://bootstrap.pypa.io/get-pip.py | python
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip install --upgrade pip && \
+    pip install --extra-index-url https://download.pytorch.org/whl/cu111 -r requirements.txt
+
+CMD ["python"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 datasets==2.20.0
 matplotlib==3.8.0
-numpy==2.0.1
+numpy==1.26.4
 pandas==2.2.2
 peft==0.12.0
 scikit_learn==1.3.1
 scipy==1.14.0
 seaborn==0.13.2
-torch==1.10.1+cu111
+torch==1.13.0
 tqdm==4.66.4
-transformers==4.26.0
+transformers==4.31.0

--- a/src/utils/indexing.py
+++ b/src/utils/indexing.py
@@ -464,10 +464,10 @@ def generate_metapath_id(data_path, dataset, metapath_cluster_method, metapath_c
             centroids_dict[f"<CT{center_label}>"] = centroids[d[1]]
 
     utils.save_pickle(
-        f'{data_path}/{dataset}/centroid_metapath_indexing_{metapath_cluster_method}_{metapath_cluster_num}.pkl',
+        f'{data_path}/{dataset}/centroid_metapath_indexing_{metapath_cluster_method}_{metapath_cluster_num}_ag.pkl',
         centroids_dict
     )
-    
+
     return asin2id
 
     

--- a/src/utils/indexing.py
+++ b/src/utils/indexing.py
@@ -463,8 +463,11 @@ def generate_metapath_id(data_path, dataset, metapath_cluster_method, metapath_c
         if center_label not in centroids_dict.keys():
             centroids_dict[f"<CT{center_label}>"] = centroids[d[1]]
 
-    utils.save_pickle(centroids_dict, f'{data_path}/{dataset}/centroid_metapath_indexing_{metapath_cluster_method}_{metapath_cluster_num}.pkl')
-
+    utils.save_pickle(
+        f'{data_path}/{dataset}/centroid_metapath_indexing_{metapath_cluster_method}_{metapath_cluster_num}.pkl',
+        centroids_dict
+    )
+    
     return asin2id
 
     


### PR DESCRIPTION
Fix parameter order in utils.save_pickle and update requirements

- Correct the parameter order in the call to utils.save_pickle in indexing.py (line 466).
- Append '_ag' to the output file name to align with the loading requirements.
- Update the requirements (e.g., numpy, peft, etc.) to resolve version conflicts.
- Add the Dockerfile used for training reproducibility.